### PR TITLE
fixes #2708 Fix wrong URL for twitter:image

### DIFF
--- a/src/Frontend/Modules/Blog/Actions/Detail.php
+++ b/src/Frontend/Modules/Blog/Actions/Detail.php
@@ -173,7 +173,7 @@ class Detail extends FrontendBaseBlock
         $this->header->setTwitterCard(
             $this->blogPost['title'],
             $this->blogPost['meta_description'],
-            FRONTEND_FILES_URL . '/Blog/images/source/' . $this->blogPost['image']
+            SITE_URL . '/src/Frontend/Files/Blog/images/source/' . $this->blogPost['image']
         );
     }
 


### PR DESCRIPTION
Fix incorrect URL for twitter:image

## Type
- Critical bugfix

## Resolves the following issues

fixes #2708

## Pull request description
twitter:image don't display because URL was wrong. Replace wrong URL for blog post image.

